### PR TITLE
Set simpletitle as default link text.

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -368,7 +368,7 @@ class renderer_plugin_xml extends Doku_Renderer {
      */
     function internallink($link, $title = null) {
         $this->doc .= '<link type="internal" href="' . $this->_xmlEntities($link) . '">';
-        $this->doc .= $this->_getLinkTitle($title, $link);
+        $this->doc .= $this->_getLinkTitle($title, $this->_simpleTitle($link));
         $this->doc .= '</link>';
     }
 


### PR DESCRIPTION
Use `Doku_Renderer::_simpleTitle($link)` as default for internal links' text.

It removes any NS from $link but keeps casing and special chars.
