### PR TITLE
fix of interwiki links

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -433,7 +433,7 @@ class renderer_plugin_xml extends Doku_Renderer {
     function interwikilink($link, $title = null, $wikiName, $wikiUri) {
         $name = $this->_getLinkTitle($title, $wikiUri, $isImage);
         $url = $this->_resolveInterWiki($wikiName, $wikiUri);
-        $this->doc .= '<link type="interwiki" link="'.$this->_xmlEntities($link).'" href="'.$url.'">';
+        $this->doc .= '<link type="interwiki" link="'.$this->_xmlEntities($link).'" href="'.$this->_xmlEntities($url).'">';
         $this->doc .= $name;
         $this->doc .= '</link>';
     }
@@ -617,7 +617,7 @@ class renderer_plugin_xml extends Doku_Renderer {
                               $img['height'],
                               $img['cache']);
     }
-    
+
     function _openTag($class, $func, $data=null) {
         $this->tagStack[] = array($class, $func, $data);
     }


### PR DESCRIPTION
Interwiki links are broken, specifically when there are "&" in the link the plugin produces a not well formed XML.
For an example you could see the page https://www.dokuwiki.org/wiki:welcome where there is a interwiki link ([[this>doku.php?do=admin&page=config|configuration settings]]) that is not correctly exported (the "&" character has not been correctly translated to "&amp;" in the href attribute),